### PR TITLE
Only count meetings explicitly attending

### DIFF
--- a/main.go
+++ b/main.go
@@ -180,7 +180,7 @@ func ignoreEvent(email string, event *calv3.Event) bool {
 
 	// We should ignore events the user has explicity not accepted.
 	for _, attendee := range event.Attendees {
-		if attendee.Email == email && attendee.ResponseStatus == "declined" {
+		if attendee.Email == email && attendee.ResponseStatus != "accepted" {
 			return true
 		}
 	}


### PR DESCRIPTION
Which means "maybe" and "no status" are also ignored... only
committed meetings ("attending") are counted towards meetings.